### PR TITLE
WAN-32 Fix missing script tag for firebase-firestore

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <script src="https://www.gstatic.com/firebasejs/8.6.1/firebase-app.js"></script>
 <script src="https://www.gstatic.com/firebasejs/8.6.1/firebase-auth.js"></script>
+<script src="https://www.gstatic.com/firebasejs/8.6.1/firebase-firestore.js"></script>
 <script>
   var firebaseConfig = {
     apiKey: "AIzaSyCfHtrw5qkbqYz32ez0I4HlHOhddSHs7II",


### PR DESCRIPTION
**Issue:**
App wasn't working in web browser because of a missing script tag for firebase-firestore. Not sure if we actually want to support web since the FlutterFire support for web seems to be a bit janky.

**Resolution:**
I've just added the missing script tag. In the future, every time we use a new firebase feature we should add the following script tag to web/index.html: <script src="https://www.gstatic.com/firebasejs/8.6.1/firebase-[FEATURE].js"></script>