### PR TITLE
WAN-25 Add WanderlistSummaryItem implementation

### DIFF
--- a/lib/components/wanderlist_summary_item.dart
+++ b/lib/components/wanderlist_summary_item.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+
+class WanderlistSummaryItem extends StatelessWidget {
+  final double width;
+  final double height;
+
+  final String listName;
+  final String authorName;
+  final int numTotalItems;
+  final int numCompletedItems;
+  final String imageUrl;
+
+  static const double CORNER_RADIUS = 15.0;
+
+  WanderlistSummaryItem({
+    Key? key,
+    this.width = 375.0,
+    this.height = 75.0,
+    this.listName = "",
+    this.authorName = "",
+    this.numTotalItems = 0,
+    this.numCompletedItems = 0,
+    this.imageUrl = "",
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+        height: this.height,
+        width: this.width,
+        color: Colors.transparent,
+        child: Container(
+            padding: EdgeInsets.symmetric(
+                vertical: height / 7.5, horizontal: width / 37.5),
+            decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.all(Radius.circular(CORNER_RADIUS))),
+            child: Row(children: <Widget>[
+              Expanded(
+                  flex: 17,
+                  child:
+                      _ImageComponent(this.width, this.height, this.imageUrl)),
+              Spacer(flex: 4),
+              Expanded(
+                  flex: 79,
+                  child: _TextComponent(
+                    this.listName,
+                    this.authorName,
+                    this.numTotalItems,
+                    this.numCompletedItems,
+                  )),
+            ])));
+  }
+}
+
+class _ImageComponent extends StatelessWidget {
+  final double parentWidth;
+  final double parentHeight;
+  final String imageUrl;
+
+  static const double CORNER_RADIUS = 18.0;
+
+  _ImageComponent(this.parentWidth, this.parentHeight, this.imageUrl);
+
+  @override
+  Widget build(BuildContext context) {
+    return new Center(
+      child: new AspectRatio(
+        aspectRatio: 1 / 1,
+        child: new Container(
+          decoration: new BoxDecoration(
+              borderRadius: BorderRadius.all(Radius.circular(CORNER_RADIUS)),
+              image: new DecorationImage(
+                fit: BoxFit.fitHeight,
+                alignment: FractionalOffset.topCenter,
+                image: new NetworkImage(this.imageUrl),
+              )),
+        ),
+      ),
+    );
+  }
+}
+
+class _TextComponent extends StatelessWidget {
+  final String listName;
+  final String authorName;
+  final int numTotalItems;
+  final int numCompletedItems;
+  String completed;
+
+  _TextComponent(this.listName, this.authorName, this.numTotalItems,
+      this.numCompletedItems)
+      : completed = "Completed " +
+            numCompletedItems.toString() +
+            " of " +
+            numTotalItems.toString() +
+            " activities";
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Expanded(
+              flex: 5,
+              child: Container(
+                  child: new Text(listName, style: TextStyle(fontSize: 18)))),
+          Expanded(
+              flex: 3,
+              child: Container(
+                  child: new Text("by " + this.authorName,
+                      style: TextStyle(fontSize: 12, color: Colors.grey)))),
+          Expanded(
+              flex: 3,
+              child: Container(
+                  child: new Text(this.completed,
+                      style: TextStyle(fontSize: 12, color: Colors.grey)))),
+          Expanded(flex: 1, child: Container()),
+        ]);
+  }
+}

--- a/lib/components/wanderlist_summary_item.dart
+++ b/lib/components/wanderlist_summary_item.dart
@@ -1,4 +1,48 @@
 import 'package:flutter/material.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class GetListSummary extends StatelessWidget {
+  final String activity;
+
+  GetListSummary(this.activity);
+
+  @override
+  Widget build(BuildContext context) {
+    CollectionReference activities = FirebaseFirestore.instance.collection('wanderlists');
+
+    return FutureBuilder<DocumentSnapshot>(
+      future: activities.doc(activity).get(),
+
+      builder:
+          (BuildContext context, AsyncSnapshot<DocumentSnapshot> snapshot) {
+
+        if (snapshot.hasError) {
+          return Text("Something went wrong");
+        }
+
+        if (snapshot.hasData && !snapshot.data!.exists) {
+          return Text("Document does not exist");
+        }
+
+        if (snapshot.connectionState == ConnectionState.done) {
+          Map<String, dynamic> data = snapshot.data!.data() as Map<String, dynamic>;
+
+          return WanderlistSummaryItem(
+            listName: data['name'],
+            authorName: data['author'],
+            numTotalItems: data['activities'].length,
+            numCompletedItems: data['numComplete'],
+            imageUrl: data['icon']
+          );
+          return Text("Full Name: ${data['full_name']} ${data['last_name']}");
+        }
+
+        return Text("loading");
+      },
+    );
+  }
+}
 
 class WanderlistSummaryItem extends StatelessWidget {
   final double width;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,7 +46,6 @@ class MyHomePage extends StatefulWidget {
 
 class _MyHomePageState extends State<MyHomePage> {
   @override
-
   void checkSignedIn() {
     if (true || FirebaseAuth.instance.currentUser == null) {
       Navigator.push(


### PR DESCRIPTION
### Motivation
This is an item to represent a Wanderlist summary's condensed form in a list of Wanderlists. This will be useful for the Wanderlists page where users can view all of the Wanderlists they have created/saved and also in any other locations where Wanderlists need to be shown. 

This component is completely stateless and its data, etc. is populated by the parent that it should be a part of. 

WanderlistSummaryItem:
<img src="https://user-images.githubusercontent.com/9525422/131932094-ed6ce495-9eb5-46dc-a04c-70f2618e5d22.png" width="250">

How it will appear when used on the Wanderlists page
<img src="https://user-images.githubusercontent.com/9525422/131932306-19c2b7bd-5c4c-4e3b-a4e1-03963c8e13b4.png" width="250">

### Changes
- Add wanderlist_summary_item.dart
- Create the components directory under lib (this is where all of the other components can go)
- Implement WanderlistSummaryItem