### PR TITLE
WAN-35 implement bloc pattern for homepage

### DIFF
--- a/lib/home/cubit/trip_cubit.dart
+++ b/lib/home/cubit/trip_cubit.dart
@@ -1,0 +1,17 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+part 'trip_state.dart';
+
+class TripCubit extends Cubit<TripState> {
+  // TODO: Add a parameter to here after the repository pattern is implemented
+  TripCubit() : super(TripInitial());
+
+  Future<void> getTripInfo() async {
+    // TODO: Implement properly after implementing basic repository pattern
+    // this is just a fake async call for testing.
+    emit(TripLoading());
+    await Future.delayed(Duration(seconds: 2));
+    emit(TripLoaded(3, 66, 1129));
+  }
+}

--- a/lib/home/cubit/trip_state.dart
+++ b/lib/home/cubit/trip_state.dart
@@ -1,0 +1,35 @@
+part of 'trip_cubit.dart';
+
+abstract class TripState {
+  const TripState();
+}
+
+class TripInitial implements TripState {
+  const TripInitial();
+}
+
+class TripLoading implements TripState {
+  const TripLoading();
+}
+
+class TripLoaded extends Equatable implements TripState {
+  const TripLoaded(this.numWanderlists, this.percentageComplete, this.points);
+
+  final int numWanderlists;
+  final int percentageComplete;
+  final int points;
+  // TODO: Also need a list of wanderlists here at some point once the
+  // Wanderlist model is implemented
+
+  @override
+  List<Object?> get props => [numWanderlists, percentageComplete, points];
+
+  TripLoaded copyWith({
+    int? numWanderlists,
+    int? percentageComplete,
+    int? points,
+  }) {
+    return TripLoaded(numWanderlists ?? this.numWanderlists,
+        percentageComplete ?? this.percentageComplete, points ?? this.points);
+  }
+}

--- a/lib/home/models/home_details.dart
+++ b/lib/home/models/home_details.dart
@@ -1,0 +1,1 @@
+class HomeDetails {}

--- a/lib/home/view/home_page.dart
+++ b/lib/home/view/home_page.dart
@@ -1,0 +1,59 @@
+import 'package:application/home/cubit/trip_cubit.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class HomePage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) => TripCubit(),
+      child: Column(children: [
+        Container(child: _TripInfo()),
+        Container(child: _NextRewardsInfo()),
+        Container(child: _Wanderlists()),
+      ]),
+    );
+  }
+}
+
+class _TripInfo extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return BlocConsumer<TripCubit, TripState>(
+      listener: (context, state) {},
+      builder: (context, state) {
+        return Container(
+            // TODO: Implement _TripInfo widgets
+            );
+      },
+    );
+  }
+}
+
+class _NextRewardsInfo extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return BlocConsumer<TripCubit, TripState>(
+      listener: (context, state) {},
+      builder: (context, state) {
+        return Container(
+            // TODO: Implement _NextRewardsInfo widgets
+            );
+      },
+    );
+  }
+}
+
+class _Wanderlists extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return BlocConsumer<TripCubit, TripState>(
+      listener: (context, state) {},
+      builder: (context, state) {
+        return Container(
+            // TODO: Implement _Wanderlists widgets
+            );
+      },
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -8,6 +8,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.6.1"
+  bloc:
+    dependency: "direct main"
+    description:
+      name: bloc
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "7.1.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -71,6 +78,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.3"
+  equatable:
+    dependency: "direct main"
+    description:
+      name: equatable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.3"
   fake_async:
     dependency: transitive
     description:
@@ -139,6 +153,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_bloc:
+    dependency: "direct main"
+    description:
+      name: flutter_bloc
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "7.2.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -184,6 +205,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   path:
     dependency: transitive
     description:
@@ -198,6 +226,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
+  provider:
+    dependency: transitive
+    description:
+      name: provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -261,4 +296,4 @@ packages:
     version: "2.1.0"
 sdks:
   dart: ">=2.12.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5"
+  flutter: ">=1.16.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,9 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
+  bloc: ^7.1.0
+  flutter_bloc: ^7.2.0
+  equatable: ^2.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Motivation
Implementing the BLoC pattern is important to make sure code is clean and responsive.

### Changes
- Add a cubit to represent a trip and all events related to that
- Add a state for a trip that includes all the data needed for the homepage (further additions as we create more of the models)
- Add a homepage widget with a simple empty configuration ready for implementing the actual content of the page