### PR TITLE
WAN-56 Fix user not being set correctly in user repository when user changes

### DIFF
--- a/lib/repositories/user/user_repository.dart
+++ b/lib/repositories/user/user_repository.dart
@@ -1,5 +1,3 @@
-import 'dart:developer';
-
 import 'package:application/models/user.dart';
 import 'package:application/models/user_wanderlist.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
@@ -11,15 +9,14 @@ class UserRepository implements IUserRepository {
   UserRepository() {
     final FirebaseAuth auth = FirebaseAuth.instance;
     _setUser(auth, auth.currentUser);
+    _users = FirebaseFirestore.instance.collection('users');
     auth.authStateChanges().listen((newUser) => _setUser(auth, newUser));
   }
 
   _setUser(auth, user) {
-    log("called");
     if (user != null) {
       _uid = user.uid;
     }
-    _users = FirebaseFirestore.instance.collection('users');
   }
 
   late String _uid;

--- a/lib/repositories/user/user_repository.dart
+++ b/lib/repositories/user/user_repository.dart
@@ -10,7 +10,12 @@ import 'i_user_repository.dart';
 class UserRepository implements IUserRepository {
   UserRepository() {
     final FirebaseAuth auth = FirebaseAuth.instance;
-    var user = auth.currentUser;
+    _setUser(auth, auth.currentUser);
+    auth.authStateChanges().listen((newUser) => _setUser(auth, newUser));
+  }
+
+  _setUser(auth, user) {
+    log("called");
     if (user != null) {
       _uid = user.uid;
     }


### PR DESCRIPTION
### Issue
When logged into the app then proceeding to log out and and log into another account, the data for the previous user was still being accessed. This is a security and usability issue.

### Fix
Add a listener for user auth changes in the UserRepository, setting the user stored in the repository to the correct one whenever this happens.