### PR TITLE
general cleanup and wlist/activity card interaction

### DIFF
--- a/lib/activity/view/activity_info.dart
+++ b/lib/activity/view/activity_info.dart
@@ -8,6 +8,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 const _buttonSize = 40.0;
 const _sectionSize1 = 75.0;
 const _sectionSize2 = 125.0;
+const _POINTSPADDING = 13.0;
 
 class ActivityInfo extends StatelessWidget {
   ActivityInfo(this.id, {Key? key}) : super(key: key);
@@ -22,10 +23,10 @@ class ActivityInfo extends StatelessWidget {
         body: ListView(
           children: [
             LocationImage(),
-            Stack(
+            Column (
               children: [
-                _PointsTooltip(),
                 _Title(),
+                _PointsTooltip(),
               ],
             ),
             AboutBox(),
@@ -78,23 +79,24 @@ class LocationImage extends StatelessWidget {
 class _Title extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return ClipRRect(
+    return Container (
+      color: WanColors().bgOrange,
+        child: ClipRRect (
       borderRadius: BorderRadius.only(
-        bottomLeft: Radius.circular(15.0),
-        bottomRight: Radius.circular(15.0),
+        bottomLeft: Radius.circular(WanTheme.CARD_CORNER_RADIUS),
+        bottomRight: Radius.circular(WanTheme.CARD_CORNER_RADIUS),
       ),
-      child: Container(
+      child: Stack (children: <Widget> [
+        Container(
         color: Colors.white,
-        height: _sectionSize1,
         child: Row(
           children: [
             Expanded(child: _Details(), flex: 70),
-            Expanded(child: FlagButton(), flex: 15),
             Expanded(child: LocationButton(), flex: 15),
           ],
         ),
       ),
-    );
+     ])));
   }
 }
 
@@ -106,23 +108,27 @@ class _Details extends StatelessWidget {
         builder: (context, state) {
           if (state is ActivityLoaded) {
             return Column(
-              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
-                  state.name,
-                  style: TextStyle(
-                    fontFamily: 'inter',
-                    fontWeight: FontWeight.bold,
-                    fontSize: 20,
-                    color: Colors.black,
-                  ),
-                ),
-                Text(
+                Container (
+                  padding: EdgeInsets.all(WanTheme.CARD_PADDING),
+                  child: Text(
+                    state.name,
+                    overflow: TextOverflow.ellipsis,
+                    maxLines: 3,
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 20,
+                      color: Colors.black,
+                    ),
+                )),
+                Container (
+                  padding: EdgeInsets.only(left: WanTheme.CARD_PADDING, bottom: WanTheme.CARD_PADDING),
+                    child: Text(
                   state.address,
-                  style: TextStyle(
-                    fontFamily: 'inter',
-                  ),
-                )
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ))
               ],
             );
           } else {
@@ -137,13 +143,15 @@ class _PointsTooltip extends StatelessWidget {
   Widget build(BuildContext context) {
     return ClipRRect(
       borderRadius: BorderRadius.only(
-        bottomLeft: Radius.circular(15.0),
-        bottomRight: Radius.circular(15.0),
+        bottomLeft: Radius.circular(WanTheme.CARD_CORNER_RADIUS),
+        bottomRight: Radius.circular(WanTheme.CARD_CORNER_RADIUS),
       ),
       child: Container(
-        padding: EdgeInsets.only(top: _sectionSize1),
-        height: _sectionSize2,
         color: WanTheme.colors.bgOrange,
+        padding: EdgeInsets.only(
+          top: _POINTSPADDING,
+          bottom: _POINTSPADDING,
+        ),
         child: Center(
           child: BlocConsumer<ActivityCubit, ActivityState>(
             listener: (context, state) {},

--- a/lib/apptheme.dart
+++ b/lib/apptheme.dart
@@ -17,7 +17,8 @@ class WanTextTheme {
 
   var errorLabel = TextStyle(color: Colors.red);
 
-  var cardTitle = TextStyle(fontSize: 18);
+  var heading = TextStyle(fontSize: 18);
+  var cardTitle = TextStyle(fontSize: 14);
   var cardBody = TextStyle(color: WanColors().grey, fontSize: 12);
 
   var loginButton = TextStyle(
@@ -57,6 +58,7 @@ Color tintColor(Color color, double factor) => Color.fromRGBO(
 
 class WanTheme {
   static const double CARD_CORNER_RADIUS = 15.0;
+  static const double THUMB_CORNER_RADIUS = 5.0;
   static const double BORDER_RADIUS = 15.0;
   static const double PAGE_MARGIN = 20;
   static const double CARD_PADDING = 8;

--- a/lib/apptheme.dart
+++ b/lib/apptheme.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter/material.dart';
+import 'dart:math';
+import 'package:flutter/material.dart';
 
 // These should be generic text styles, eg "label", "title", "button1", "button2"
 // loginButton and signupButton are temporary to illustrate how they are used,
@@ -16,7 +18,7 @@ class WanTextTheme {
   var errorLabel = TextStyle(color: Colors.red);
 
   var cardTitle = TextStyle(fontSize: 18);
-  var cardBody = TextStyle(color: Color(0x999999), fontSize: 12);
+  var cardBody = TextStyle(color: WanColors().grey, fontSize: 12);
 
   var loginButton = TextStyle(
     color: Colors.white,
@@ -26,11 +28,63 @@ class WanTextTheme {
   var signupButton = TextStyle(color: WanTheme.colors.pink, fontSize: 15);
 }
 
+
+// Source
+// https://gist.github.com/moritzmorgenroth/5602102d855efde2d686b0c7c5a095ad
+MaterialColor generateMaterialColor(Color color) {
+  return MaterialColor(color.value, {
+    50: tintColor(color, 0.5),
+    100: tintColor(color, 0.4),
+    200: tintColor(color, 0.3),
+    300: tintColor(color, 0.2),
+    400: tintColor(color, 0.1),
+    500: tintColor(color, 0),
+    600: tintColor(color, -0.1),
+    700: tintColor(color, -0.2),
+    800: tintColor(color, -0.3),
+    900: tintColor(color, -0.4),
+  });
+}
+
+int tintValue(int value, double factor) =>
+    max(0, min((value + ((255 - value) * factor)).round(), 255));
+
+Color tintColor(Color color, double factor) => Color.fromRGBO(
+    tintValue(color.red, factor),
+    tintValue(color.green, factor),
+    tintValue(color.blue, factor),
+    1);
+
 class WanTheme {
   static const double CARD_CORNER_RADIUS = 15.0;
+  static const double BORDER_RADIUS = 15.0;
+  static const double PAGE_MARGIN = 20;
+  static const double CARD_PADDING = 8;
+  static const double TITLEBAR_HEIGHT = 60;
+
+  static ColorScheme defaultCols = ColorScheme(
+  background: Colors.white,
+  brightness: Brightness.light,
+  primary: WanColors().pink,
+  onPrimary: Colors.white,
+  primaryVariant: WanColors().bgOrange,
+  surface: WanColors().offWhite,
+  onBackground: Colors.black,
+  secondary: WanColors().bgOrange,
+  onSecondary: WanColors().orange,
+  secondaryVariant: WanColors().bgOrange,
+  onSurface: Colors.black,
+  error: Colors.red,
+  onError: Colors.white,
+  );
 
   static ThemeData materialTheme = ThemeData(
-    primarySwatch: Colors.pink,
+    primarySwatch: generateMaterialColor(WanColors().pink),
+
+    colorScheme: defaultCols,
+    iconTheme: IconThemeData(color: WanColors().pink),
+    primaryIconTheme: IconThemeData(color: WanColors().pink),
+    accentIconTheme: IconThemeData(color: WanColors().pink),
     fontFamily: "inter",
     textTheme: const TextTheme(
       headline1: TextStyle(fontSize: 72.0, fontWeight: FontWeight.bold),
@@ -43,18 +97,23 @@ class WanTheme {
       button: TextStyle(fontSize: 14),
       caption: TextStyle(fontSize: 12),
 
-      bodyText1: TextStyle(fontSize: 14.0),
+      bodyText1: TextStyle(fontSize: 14.0, color: Colors.grey),
       // ...
-      bodyText2: TextStyle(fontSize: 12.0, color: Colors.grey),
+      bodyText2: TextStyle(fontSize: 12.0, color: Colors.black),
     ),
   );
 
   static WanTextTheme text = WanTextTheme();
   static WanColors colors = WanColors();
+
+
 }
 
+
+
+
 class WanColors {
-  var pink = Color.fromRGBO(0xFF, 0x2D, 0x55, 0.9);
+  var pink = Color(0xFFFE4165);
   var grey = Color.fromRGBO(0x42, 0x42, 0x42, 0.9);
   var offWhite = Color.fromRGBO(0xF6, 0xF6, 0xF6, 1);
   var bgOrange = Color.fromRGBO(0xFF, 0xDC, 0xC1, 1);

--- a/lib/components/activity_summary_item_large.dart
+++ b/lib/components/activity_summary_item_large.dart
@@ -1,3 +1,4 @@
+import 'package:application/activity/view/activity_info.dart';
 import 'package:application/models/activity.dart';
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -11,25 +12,22 @@ class ActivitySummaryItemLarge extends ActivitySummaryItemSmall {
   final ActivityDetails activity;
   final double height;
   final double width;
-  final String activityName;
-  final String activityDescription;
-  final String documentName;
-  final String imageUrl;
-  final bool complete;
+  final bool? complete;
 
   ActivitySummaryItemLarge(this.activity,
       {Key? key,
-      this.activityName = "",
-      this.activityDescription = "",
-      this.documentName = "",
-      this.imageUrl = "",
+        this.complete,
       this.width = 375,
-      this.height = 75.0 * 3.4,
-      this.complete = false});
+      this.height = 75.0 * 3.4}) : super(activity: activity);
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    return GestureDetector (
+        onTap:() => Navigator.push(
+        context,
+        MaterialPageRoute(
+            builder: (context) => ActivityInfo(activity.id))),
+    child: Container(
         height: SizeConfig(context).w / 2 + 75,
         width: SizeConfig(context).w,
         color: Colors.transparent,
@@ -53,7 +51,7 @@ class ActivitySummaryItemLarge extends ActivitySummaryItemSmall {
                   padding: EdgeInsets.only(right: 8),
                     child: Icon(Icons.chevron_right, color: Colors.grey)),
               ]),
-            ])));
+            ]))));
   }
 }
 

--- a/lib/components/activity_summary_item_small.dart
+++ b/lib/components/activity_summary_item_small.dart
@@ -115,11 +115,14 @@ class _TextComponent extends StatelessWidget {
           Container(
               padding: const EdgeInsets.only(bottom: 3),
               child: new Text(activityName,
-                  style: WanTheme.materialTheme.textTheme.headline5)),
+                  style: WanTheme.materialTheme.textTheme.headline5,
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 1),
+                ),
           Container(
               child: Text(
             activityDescription,
-            style: WanTheme.materialTheme.textTheme.bodyText2,
+            style: Theme.of(context).textTheme.caption,
             overflow: TextOverflow.ellipsis,
             softWrap: true,
             maxLines: 2,

--- a/lib/components/activity_summary_item_small.dart
+++ b/lib/components/activity_summary_item_small.dart
@@ -1,3 +1,5 @@
+import 'package:application/activity/view/activity_info.dart';
+import 'package:application/models/activity.dart';
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
@@ -9,27 +11,32 @@ class ActivitySummaryItemSmall extends StatelessWidget {
   final double width;
   final String activityName;
   final String activityDescription;
-  final String documentName;
   final String imageUrl;
-  final bool complete;
+  final bool? complete;
   final Widget? rightWidget;
   final bool smallIcon;
+  final ActivityDetails activity;
 
   ActivitySummaryItemSmall(
       {Key? key,
-      this.activityName = "",
-      this.activityDescription = "",
-      this.documentName = "",
-      this.imageUrl = "",
+        required this.activity,
       this.width = 375.0,
       this.height = 75.0,
-      this.complete = false,
       this.rightWidget = const Icon(Icons.chevron_right, color: Colors.grey),
-      this.smallIcon = false});
+      this.smallIcon = false,
+        this.complete})
+  : activityName = activity.name,
+    imageUrl = activity.imageUrl,
+    activityDescription = activity.about;
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    return GestureDetector  (
+      onTap:() => Navigator.push(
+          context,
+          MaterialPageRoute(
+              builder: (context) => ActivityInfo(activity.id))),
+    child: Container(
         height: this.height,
         width: this.width,
         color: Colors.transparent,
@@ -51,7 +58,7 @@ class ActivitySummaryItemSmall extends StatelessWidget {
               Container(
                   padding: EdgeInsets.only(right: 8),
                   child: this.rightWidget),
-            ])));
+            ]))));
   }
 }
 

--- a/lib/components/activity_summary_item_small.dart
+++ b/lib/components/activity_summary_item_small.dart
@@ -78,7 +78,7 @@ class _ImageComponent extends StatelessWidget {
         bottomLeft: Radius.circular(WanTheme.CARD_CORNER_RADIUS));
     double iconHeight = this.parentHeight;
     if (this.smallIcon) {
-      borderRadius = BorderRadius.circular(WanTheme.CARD_CORNER_RADIUS);
+      borderRadius = BorderRadius.circular(WanTheme.THUMB_CORNER_RADIUS);
       iconHeight = this.parentHeight * 0.8;
     }
 
@@ -115,7 +115,7 @@ class _TextComponent extends StatelessWidget {
           Container(
               padding: const EdgeInsets.only(bottom: 3),
               child: new Text(activityName,
-                  style: WanTheme.materialTheme.textTheme.headline5,
+                  style: WanTheme.text.cardTitle,
                   overflow: TextOverflow.ellipsis,
                   maxLines: 1),
                 ),

--- a/lib/components/searchfield.dart
+++ b/lib/components/searchfield.dart
@@ -1,0 +1,36 @@
+
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+
+class SearchField extends StatelessWidget {
+  final String hint;
+
+  SearchField(this.hint);
+
+  static InputDecoration defaultDecoration = InputDecoration(
+    contentPadding: EdgeInsets.only(left: 15),
+    border: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(25.0),
+      borderSide: BorderSide(
+        width: 0,
+        style: BorderStyle.none,
+      ),
+    ),
+    filled: true,
+    hintStyle: TextStyle(color: Colors.grey[800], height: 1),
+    fillColor: Colors.grey[300],
+  );
+
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 40,
+      child: TextField(
+        decoration: defaultDecoration.copyWith(hintText: hint),
+//        style: TextStyle(height: 1),
+      ),
+    );
+  }
+}

--- a/lib/components/small_square_image.dart
+++ b/lib/components/small_square_image.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 
+import '../apptheme.dart';
+
 class SmallSquareImage extends StatelessWidget {
   final double parentWidth;
   final double parentHeight;
   final ImageProvider image;
-
-  static const double CORNER_RADIUS = 4.0;
 
   SmallSquareImage(this.parentWidth, this.parentHeight, this.image);
 
@@ -16,7 +16,7 @@ class SmallSquareImage extends StatelessWidget {
         aspectRatio: 1 / 1,
         child: Container(
           decoration: BoxDecoration(
-              borderRadius: BorderRadius.all(Radius.circular(CORNER_RADIUS)),
+              borderRadius: BorderRadius.all(Radius.circular(WanTheme.THUMB_CORNER_RADIUS)),
               image: DecorationImage(
                 fit: BoxFit.fitHeight,
                 alignment: FractionalOffset.topCenter,

--- a/lib/components/wanderlist_summary_item.dart
+++ b/lib/components/wanderlist_summary_item.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
+import '../apptheme.dart';
+
 class GetListSummary extends StatelessWidget {
   final String activity;
 
@@ -54,8 +56,6 @@ class WanderlistSummaryItem extends StatelessWidget {
   final int numCompletedItems;
   final String imageUrl;
 
-  static const double CORNER_RADIUS = 15.0;
-
   WanderlistSummaryItem({
     Key? key,
     this.width = 375.0,
@@ -78,7 +78,7 @@ class WanderlistSummaryItem extends StatelessWidget {
                 vertical: height / 7.5, horizontal: width / 37.5),
             decoration: BoxDecoration(
                 color: Colors.white,
-                borderRadius: BorderRadius.all(Radius.circular(CORNER_RADIUS))),
+                borderRadius: BorderRadius.all(Radius.circular(WanTheme.CARD_CORNER_RADIUS))),
             child: Row(children: <Widget>[
               Expanded(
                   flex: 17,
@@ -102,8 +102,6 @@ class _ImageComponent extends StatelessWidget {
   final double parentHeight;
   final String imageUrl;
 
-  static const double CORNER_RADIUS = 18.0;
-
   _ImageComponent(this.parentWidth, this.parentHeight, this.imageUrl);
 
   @override
@@ -113,7 +111,7 @@ class _ImageComponent extends StatelessWidget {
         aspectRatio: 1 / 1,
         child: new Container(
           decoration: new BoxDecoration(
-              borderRadius: BorderRadius.all(Radius.circular(CORNER_RADIUS)),
+              borderRadius: BorderRadius.all(Radius.circular(WanTheme.THUMB_CORNER_RADIUS)),
               image: new DecorationImage(
                 fit: BoxFit.fitHeight,
                 alignment: FractionalOffset.topCenter,
@@ -148,12 +146,12 @@ class _TextComponent extends StatelessWidget {
           Expanded(
               flex: 5,
               child: Container(
-                  child: new Text(listName, style: TextStyle(fontSize: 18)))),
+                  child: new Text(listName, style: WanTheme.text.cardTitle))),
           Expanded(
               flex: 3,
               child: Container(
                   child: new Text("by " + this.authorName,
-                      style: TextStyle(fontSize: 12, color: Colors.grey)))),
+                      style: Theme.of(context).textTheme.caption))),
           Expanded(
               flex: 3,
               child: Container(

--- a/lib/home/view/home_page.dart
+++ b/lib/home/view/home_page.dart
@@ -115,7 +115,13 @@ class _FilledHomePage extends StatelessWidget {
     return BlocConsumer<TripCubit, TripState>(
       listener: (context, state) {},
       builder: (context, state) {
-        return Column(
+        return
+        ListView(children: <Widget>[
+            Container (
+              height: SizeConfig(context).h,
+          padding: EdgeInsets.only(left: WanTheme.CARD_PADDING,
+              right: WanTheme.CARD_PADDING),
+            child: Column(
           children: [
             Container(
               padding: EdgeInsets.only(top: 50),
@@ -132,7 +138,7 @@ class _FilledHomePage extends StatelessWidget {
               child: _Wanderlists(width, wanderlistHeight),
             ),
           ],
-        );
+        ))]);
       },
     );
   }

--- a/lib/home/widgets/detailed_wanderlist_summary.dart
+++ b/lib/home/widgets/detailed_wanderlist_summary.dart
@@ -3,6 +3,7 @@ import 'package:application/components/small_square_image.dart';
 import 'package:application/models/activity.dart';
 import 'package:application/models/user_wanderlist.dart';
 import 'package:application/repositories/activity/activity_repository.dart';
+import 'package:application/wanderlist/view/wanderlist.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 
@@ -31,7 +32,9 @@ class DetailedWanderlistSummary extends StatelessWidget {
           borderRadius: BorderRadius.all(Radius.circular(CORNER_RADIUS))),
       child: Column(
         children: [
-          _TopSummary(this.width, 60, name, total, completed),
+          GestureDetector(onTap: () => Navigator.push(context,
+              MaterialPageRoute<void>(builder: (context) => WanderlistPage(userWanderlist))),
+            child: _TopSummary(this.width, 60, name, total, completed)),
           Divider(color: Colors.grey),
           _Activity(this.width, 70, nextActivity),
           _NMoreItems(total - 1),

--- a/lib/home/widgets/detailed_wanderlist_summary.dart
+++ b/lib/home/widgets/detailed_wanderlist_summary.dart
@@ -7,6 +7,8 @@ import 'package:application/wanderlist/view/wanderlist.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 
+import '../../apptheme.dart';
+
 class DetailedWanderlistSummary extends StatelessWidget {
   final double width;
   final double height;
@@ -61,13 +63,13 @@ class _TopSummary extends StatelessWidget {
         child:
             Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
           Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-            Text(this.wanderlistName, style: TextStyle(fontSize: 18)),
+            Text(this.wanderlistName, style: WanTheme.text.cardTitle),
             Text(
                 this.numCompleteActivities.toString() +
                     " out of " +
                     this.numTotalActivities.toString() +
                     " complete",
-                style: TextStyle(fontSize: 12, color: Colors.grey))
+                style: Theme.of(context).textTheme.caption)
           ]),
           Icon(
             Icons.chevron_right_outlined,
@@ -121,7 +123,7 @@ class _ActivityName extends StatelessWidget {
           flex: 100,
           child: Container(
               alignment: Alignment.centerLeft,
-              child: Text(this.activityName, style: TextStyle(fontSize: 16)))),
+              child: Text(this.activityName, style: WanTheme.text.cardTitle))),
       Expanded(flex: 1, child: Divider(color: Colors.grey))
     ]);
   }

--- a/lib/titlebar.dart
+++ b/lib/titlebar.dart
@@ -25,7 +25,7 @@ class Titlebar extends StatelessWidget implements PreferredSizeWidget {
   }
 
   static const titleSize = 30.0;
-  static const barHeight = 60.0;
+  static const barHeight = WanTheme.TITLEBAR_HEIGHT;
 
   @override
   Size get preferredSize => Size.fromHeight(barHeight);

--- a/lib/userwanderlists/view/userwanderlists.dart
+++ b/lib/userwanderlists/view/userwanderlists.dart
@@ -9,6 +9,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import '../../apptheme.dart';
 import '../cubit/userwanderlists_cubit.dart';
 import '../cubit/userwanderlists_state.dart';
 
@@ -32,7 +33,8 @@ class _WanderlistsView extends StatelessWidget {
           return ReorderableListView(
               header: Padding(
                 // search bar
-                padding: EdgeInsets.symmetric(horizontal: 8, vertical: 16),
+                padding: EdgeInsets.symmetric(horizontal: WanTheme.CARD_PADDING,
+                    vertical: 2 * WanTheme.CARD_PADDING),
                 child: TextField(
                   keyboardType: TextInputType.text,
                   onChanged: (value) {
@@ -47,7 +49,7 @@ class _WanderlistsView extends StatelessWidget {
               scrollDirection: Axis.vertical,
               shrinkWrap: true,
               primary: true,
-              padding: EdgeInsets.all(8),
+              padding: EdgeInsets.all(WanTheme.CARD_PADDING),
               physics: ClampingScrollPhysics(),
               onReorder: (int o, int n) {
                 context.read<UserWanderlistsCubit>().swap(o, n);
@@ -81,7 +83,7 @@ class _TappableWanderlistCard extends StatelessWidget {
         ),
       ),
       child: Container(
-          margin: EdgeInsets.only(bottom: 8),
+          margin: EdgeInsets.only(bottom: WanTheme.CARD_PADDING),
           key: ValueKey(userWanderlist.wanderlist.hashCode),
           child: WanderlistSummaryItem(
             imageUrl: userWanderlist.wanderlist.icon,
@@ -98,7 +100,6 @@ class UserWanderlistsPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: EdgeInsets.only(left: 8, right: 8),
       child: UserWanderlists(),
     );
   }

--- a/lib/userwanderlists/view/userwanderlists.dart
+++ b/lib/userwanderlists/view/userwanderlists.dart
@@ -1,3 +1,4 @@
+import 'package:application/components/searchfield.dart';
 import 'package:application/components/wanderlist_summary_item.dart';
 import 'package:application/models/user_wanderlist.dart';
 import 'package:application/repositories/user/user_repository.dart';
@@ -40,10 +41,9 @@ class _WanderlistsView extends StatelessWidget {
                   onChanged: (value) {
                     context.read<UserWanderlistsCubit>().filter_search(value);
                   },
-                  decoration: InputDecoration(
-                    border: OutlineInputBorder(),
-                    hintText: 'Search Your Wanderlists',
-                  ),
+                  decoration: SearchField.defaultDecoration.copyWith(
+                    hintText: "Search Your Wanderlists",
+                  )
                 ),
               ),
               scrollDirection: Axis.vertical,

--- a/lib/wanderlist/view/edit_wanderlist.dart
+++ b/lib/wanderlist/view/edit_wanderlist.dart
@@ -23,13 +23,15 @@ class EditWanderlistPage extends StatelessWidget {
 class _AppBar extends StatelessWidget implements PreferredSizeWidget {
   _AppBar();
 
-  static const barHeight = 40.0;
+  static const barHeight = WanTheme.TITLEBAR_HEIGHT;
   @override
   Size get preferredSize => Size.fromHeight(barHeight);
 
   Widget _cancelButton(BuildContext context) {
     return IconButton(
-      icon: Icon(Icons.close_outlined),
+
+      icon: Icon(Icons.close_rounded,
+        color: Theme.of(context).accentColor),
       onPressed: () {
         context.read<WanderlistCubit>().cancelEdit();
       },
@@ -37,18 +39,12 @@ class _AppBar extends StatelessWidget implements PreferredSizeWidget {
   }
 
   Widget _saveButton(BuildContext context) {
-    return Container(
-      width: 50,
-      height: 20,
-      decoration: BoxDecoration(
-          color: Colors.pink, borderRadius: BorderRadius.circular(10)),
-      child: TextButton(
+    return
+      ElevatedButton (
         onPressed: () {
           context.read<WanderlistCubit>().endEdit();
         },
-        child:
-            Text("Save", style: TextStyle(fontSize: 10, color: Colors.white)),
-      ),
+        child: Text("Save")
     );
   }
 
@@ -180,9 +176,9 @@ class _EditableActivityList extends StatelessWidget {
           if (state is Editing) {
             return Container(
               width: MediaQuery.of(context).size.width * 0.95,
-              padding: EdgeInsets.all(8.0),
+              padding: EdgeInsets.all(WanTheme.CARD_PADDING),
               decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(15.0),
+                  borderRadius: BorderRadius.circular(WanTheme.CARD_CORNER_RADIUS),
                   color: Colors.white),
               child: ReorderableListView.builder(
                 shrinkWrap: true,
@@ -228,7 +224,6 @@ class _EditableActivityListItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      decoration: BoxDecoration(color: Colors.white),
       child: Row(
         children: [
           IconButton(

--- a/lib/wanderlist/view/edit_wanderlist.dart
+++ b/lib/wanderlist/view/edit_wanderlist.dart
@@ -240,9 +240,7 @@ class _EditableActivityListItem extends StatelessWidget {
           ),
           ActivitySummaryItemSmall(
             width: MediaQuery.of(context).size.width * 0.75,
-            activityName: activity.name,
-            activityDescription: activity.about,
-            imageUrl: activity.imageUrl,
+            activity: activity,
             rightWidget: Icon(Icons.drag_handle, color: Colors.grey),
             smallIcon: true,
           ),

--- a/lib/wanderlist/view/view_wanderlist.dart
+++ b/lib/wanderlist/view/view_wanderlist.dart
@@ -129,9 +129,7 @@ class _UneditableActivityList extends StatelessWidget {
         shrinkWrap: true,
         itemBuilder: (BuildContext context, int index) {
           return ActivitySummaryItemSmall(
-            activityName: activities[index].name,
-            activityDescription: activities[index].about,
-            imageUrl: activities[index].imageUrl,
+            activity: activities[index],
             smallIcon: true,
           );
         },

--- a/lib/wanderlist/view/view_wanderlist.dart
+++ b/lib/wanderlist/view/view_wanderlist.dart
@@ -44,7 +44,7 @@ class ViewWanderlistPage extends StatelessWidget {
 class _AppBar extends StatelessWidget implements PreferredSizeWidget {
   _AppBar();
 
-  static const barHeight = 40.0;
+  static const barHeight = WanTheme.TITLEBAR_HEIGHT;
   @override
   Size get preferredSize => Size.fromHeight(barHeight);
 

--- a/lib/wanderlist/widgets/add_activity.dart
+++ b/lib/wanderlist/widgets/add_activity.dart
@@ -1,4 +1,5 @@
 import 'package:application/components/activity_summary_item_small.dart';
+import 'package:application/components/searchfield.dart';
 import 'package:application/models/activity.dart';
 import 'package:application/wanderlist/cubit/suggestions_cubit.dart';
 import 'package:application/wanderlist/cubit/suggestions_state.dart'
@@ -34,7 +35,7 @@ class AddActivityOverlay extends StatelessWidget {
             Padding(
               padding: EdgeInsets.only(bottom: 10),
             ),
-            _Search(),
+            SearchField("Search Activities"),
             Padding(
               padding: EdgeInsets.only(bottom: 10),
             ),
@@ -59,31 +60,6 @@ class AddActivityOverlay extends StatelessWidget {
   }
 }
 
-class _Search extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      height: 40,
-      child: TextField(
-        decoration: InputDecoration(
-          contentPadding: EdgeInsets.only(left: 15),
-          border: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(25.0),
-            borderSide: BorderSide(
-              width: 0,
-              style: BorderStyle.none,
-            ),
-          ),
-          filled: true,
-          hintStyle: TextStyle(color: Colors.grey[800], height: 1),
-          hintText: "Search activities",
-          fillColor: Colors.grey[300],
-        ),
-        style: TextStyle(height: 1),
-      ),
-    );
-  }
-}
 
 class _Suggestions extends StatelessWidget {
   @override
@@ -181,7 +157,7 @@ class _SuggestionsItem extends StatelessWidget {
           );
         }
 
-        return Text("Impossible state");
+        throw Exception("Impossible state");
       },
       listener: (context, state) {},
     );

--- a/lib/wanderlist/widgets/add_activity.dart
+++ b/lib/wanderlist/widgets/add_activity.dart
@@ -165,9 +165,7 @@ class _SuggestionsItem extends StatelessWidget {
               Expanded(
                 flex: 13,
                 child: ActivitySummaryItemSmall(
-                  activityName: activity.name,
-                  activityDescription: activity.about,
-                  imageUrl: activity.imageUrl,
+                  activity: activity,
                   smallIcon: true,
                   rightWidget: Container(
                     height: 20,

--- a/lib/wanderlist/widgets/add_activity.dart
+++ b/lib/wanderlist/widgets/add_activity.dart
@@ -10,6 +10,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:sliding_up_panel/sliding_up_panel.dart';
 
+import '../../apptheme.dart';
+
 class AddActivityOverlay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
@@ -21,7 +23,7 @@ class AddActivityOverlay extends StatelessWidget {
         padding: EdgeInsets.only(left: 16.0, right: 16.0, top: 4.0),
         child: Column(
           children: [
-            Icon(Icons.horizontal_rule, color: Colors.grey),
+            Icon(Icons.horizontal_rule, color: WanColors().grey),
             Text("Find Activities",
                 style: TextStyle(
                     fontSize: 24,


### PR DESCRIPTION
## Motivation 

Clean up ui and codebase a little, add interactivty to wanderlist and activity cards as expected.

## Changes

- fix the activity page so it handles long activity and place names correctly and responsively
- make all activity and wanderlist cards tappable so they navigate to the appropriate page
- modify apptheme so that backbuttons in the nav bar inherit the right colour by default
- modify the apptheme so that text appears an appropriate colour
- removed the flag button from the activity page
- changed the appbar size in the wanderlist page to match the home pages
- in many places replace literals and direct references to styling with more relevant values from contextual apptheme or the style class
- factor out the search bar from the edit_wanderlist and reuse on the wanderlists page 
- add a constant THUMB_CORNER_RADIUS = 5 and set all thumbnails to use it
- change font sizes to be more consistent
    - cardTitle 14pt black
    - card content is Theme.caption (12 pt grey)
    - subheadings are 18pt black

## Not addressed

Home page is still broken