### PR TITLE
WAN-89: Change app name to be Wanderlist

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="dev.flutter.wanderlist">
    <application
-        android:label="wanderlist"
+        android:label="Wanderlist" <!-- App name -->
         android:icon="@mipmap/ic_launcher"
         android:networkSecurityConfig="@xml/network_security_config">
         <activity

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="dev.flutter.wanderlist">
-   <application
-        android:label="Wanderlist" <!-- App name -->
+    <!-- Label: App name -->
+    <application
+        android:label="Wanderlist"
         android:icon="@mipmap/ic_launcher"
         android:networkSecurityConfig="@xml/network_security_config">
         <activity

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>application</string>
+	<string>Wanderlist</string> <!-- App name -->
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
# Motivation
Currently, the app name on Android is `wanderlist` and on iOS is `application`. This PR makes them both `Wanderlist`

# Changes
- Change app name to Wanderlist in Android and iOS