### PR TITLE
WAN-97 Add pinned wanderlists widget

### DIFF
--- a/lib/apptheme.dart
+++ b/lib/apptheme.dart
@@ -58,6 +58,7 @@ Color tintColor(Color color, double factor) => Color.fromRGBO(
 class WanTheme {
   static const double CARD_CORNER_RADIUS = 15.0;
   static const double THUMB_CORNER_RADIUS = 5.0;
+  static const double BUTTON_CORNER_RADIUS = 10.0;
   static const double BORDER_RADIUS = 15.0;
   static const double PAGE_MARGIN = 20;
   static const double CARD_PADDING = 8;

--- a/lib/home/cubit/user_cubit.dart
+++ b/lib/home/cubit/user_cubit.dart
@@ -21,14 +21,13 @@ class UserCubit extends Cubit<UserState> {
   Future<void> getTripInfo() async {
     emit(UserLoading());
     UserDetails user = await userRepository.getUserData();
-    List<UserWanderlist> wanderlists =
+    List<UserWanderlist> userWanderlists =
         (await userRepository.getActiveWanderlists()).toList();
+    List<Wanderlist> wanderlists = userWanderlists
+        .map((userWanderlist) => userWanderlist.wanderlist)
+        .toList();
 
-    int numWanderlists = wanderlists.length;
-    int percentageComplete = calculatePercentageComplete(wanderlists);
-    int totalPoints = calculateTotalPoints(wanderlists);
-
-    emit(UserLoaded(442, 1000 - 442, 1000, 442 / 1000));
+    emit(UserLoaded(442, 1000 - 442, 1000, 442 / 1000, wanderlists));
   }
 
   int calculatePercentageComplete(List<UserWanderlist> wanderlists) {

--- a/lib/home/cubit/user_state.dart
+++ b/lib/home/cubit/user_state.dart
@@ -13,15 +13,25 @@ class UserLoading implements UserState {
 }
 
 class UserLoaded extends Equatable implements UserState {
-  const UserLoaded(this.points, this.pointsUntilReward,
-      this.nextRewardTotalPoints, this.percentageUntilReward);
+  const UserLoaded(
+      this.points,
+      this.pointsUntilReward,
+      this.nextRewardTotalPoints,
+      this.percentageUntilReward,
+      this.pinnedWanderlists);
 
   final int points;
   final int pointsUntilReward;
   final int nextRewardTotalPoints;
   final double percentageUntilReward;
+  final List<Wanderlist> pinnedWanderlists;
 
   @override
-  List<Object?> get props =>
-      [points, pointsUntilReward, nextRewardTotalPoints, percentageUntilReward];
+  List<Object?> get props => [
+        points,
+        pointsUntilReward,
+        nextRewardTotalPoints,
+        percentageUntilReward,
+        pinnedWanderlists,
+      ];
 }

--- a/lib/home/view/home_page.dart
+++ b/lib/home/view/home_page.dart
@@ -1,5 +1,6 @@
 import 'package:application/apptheme.dart';
 import 'package:application/home/cubit/user_cubit.dart';
+import 'package:application/home/widgets/pinned_wanderlists.dart';
 import 'package:application/home/widgets/reward_info.dart';
 import 'package:application/home/widgets/wanderlists_list_view.dart';
 import 'package:application/repositories/user/user_repository.dart';
@@ -10,7 +11,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 Widget _emptyOrFilledHomePage(numWanderlists, gotoWanderlistsPage) {
   if (numWanderlists > 0) {
-    return _FilledHomePage();
+    return _FilledHomePage(gotoWanderlistsPage);
   }
   return _EmptyHomePage(gotoWanderlistsPage);
 }
@@ -41,7 +42,7 @@ class HomePage extends StatelessWidget {
                 alignment: Alignment.center,
                 children: <Widget>[
                   ListView(),
-                  _FilledHomePage(),
+                  _FilledHomePage(gotoWanderlistsPage),
                 ],
               ),
             );
@@ -102,27 +103,53 @@ class _EmptyHomePage extends StatelessWidget {
 /// The only way to get to this state is to have loaded user data and
 /// the ui showing > 0 wanderlists.
 class _FilledHomePage extends StatelessWidget {
-  Widget build(BuildContext context) {
+  _FilledHomePage(this.gotoWanderlistsPage);
+
+  final Function() gotoWanderlistsPage;
+
+  Column _homepageItems(BuildContext context, UserLoaded state) {
     double width = MediaQuery.of(context).size.width;
     double height = MediaQuery.of(context).size.height;
 
     double tripInfoHeight = 130;
     double wanderlistHeight = height - tripInfoHeight;
 
+    return Column(
+      children: <Widget>[
+        Container(
+          // height: SizeConfig(context).h,
+          child: ListView(
+            shrinkWrap: true,
+            children: [
+              Container(
+                child: _TripInfo(width, tripInfoHeight),
+              ),
+              Padding(padding: EdgeInsets.only(top: 20.0)),
+              Padding(
+                padding: EdgeInsets.only(left: 8.0, right: 8.0),
+                child: PinnedWanderlists(
+                  state.pinnedWanderlists,
+                  gotoWanderlistsPage,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget build(BuildContext context) {
     return BlocConsumer<UserCubit, UserState>(
       listener: (context, state) {},
       builder: (context, state) {
-        return
-        ListView(children: <Widget>[
-            Container (
-              height: SizeConfig(context).h,
-            child: Column(
-          children: [
-            Container(
-              child: _TripInfo(width, tripInfoHeight),
-            ),
-          ],
-        ))]);
+        if (state is UserLoaded) {
+          return _homepageItems(context, state);
+        } else {
+          return Container();
+        }
+
+        return Container();
       },
     );
   }

--- a/lib/home/widgets/pinned_wanderlists.dart
+++ b/lib/home/widgets/pinned_wanderlists.dart
@@ -1,0 +1,147 @@
+import 'package:application/apptheme.dart';
+import 'package:application/components/wanderlist_summary_item.dart';
+import 'package:application/models/wanderlist.dart';
+import 'package:flutter/material.dart';
+
+class PinnedWanderlists extends StatelessWidget {
+  const PinnedWanderlists(this.pinnedWanderlists, this.gotoWanderlistsPage);
+
+  final List<Wanderlist> pinnedWanderlists;
+  final Function() gotoWanderlistsPage;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        _PinnedWanderlistsContent(pinnedWanderlists),
+        _ViewAllWanderlistsButton(gotoWanderlistsPage),
+      ],
+    );
+  }
+}
+
+class _PinnedWanderlistsContent extends StatelessWidget {
+  const _PinnedWanderlistsContent(this.pinnedWanderlists);
+
+  final List<Wanderlist> pinnedWanderlists;
+
+  static const String title = "Pinned Wanderlists";
+  static const Radius corner = Radius.circular(WanTheme.CARD_CORNER_RADIUS);
+
+  Widget _contentTitle(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(left: 14.0),
+      child: RichText(
+        text: TextSpan(
+          children: [
+            WidgetSpan(
+              child: Container(),
+            ),
+            TextSpan(
+              text: title,
+              style: Theme.of(context).textTheme.headline3,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _wanderlists(BuildContext context) {
+    return ListView.builder(
+      shrinkWrap: true,
+      itemBuilder: (context, index) {
+        Wanderlist pinnedWanderlist = pinnedWanderlists[index];
+        return WanderlistSummaryItem(
+          listName: pinnedWanderlist.name,
+          authorName: pinnedWanderlist.creatorName,
+          numTotalItems: pinnedWanderlist.activities.length,
+          imageUrl: pinnedWanderlist.icon,
+        );
+      },
+      itemCount: pinnedWanderlists.length,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: WanTheme.colors.white,
+        borderRadius: BorderRadius.only(
+          topLeft: corner,
+          topRight: corner,
+        ),
+      ),
+      padding: EdgeInsets.all(10),
+      child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [_contentTitle(context), _wanderlists(context)]),
+    );
+  }
+}
+
+class _ViewAllWanderlistsButton extends StatelessWidget {
+  _ViewAllWanderlistsButton(this.gotoWanderlistsPage);
+
+  final Function() gotoWanderlistsPage;
+
+  static const Radius corner = Radius.circular(WanTheme.CARD_CORNER_RADIUS);
+
+  Widget _background(BuildContext context) {
+    return Column(
+      children: [
+        Container(
+          height: 25,
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.only(
+              bottomLeft: corner,
+              bottomRight: corner,
+            ),
+            color: WanTheme.colors.white,
+          ),
+        ),
+        Container(
+          height: 25,
+        ),
+      ],
+    );
+  }
+
+  Widget _button(BuildContext context) {
+    return Center(
+      child: ElevatedButton(
+        style: ButtonStyle(
+          shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+            RoundedRectangleBorder(
+              borderRadius: BorderRadius.all(
+                Radius.circular(WanTheme.BUTTON_CORNER_RADIUS),
+              ),
+            ),
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Text(
+            "View all Wanderlists",
+            style: Theme.of(context)
+                .textTheme
+                .headline4!
+                .copyWith(color: WanTheme.colors.white),
+          ),
+        ),
+        onPressed: () => gotoWanderlistsPage(),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        _background(context),
+        _button(context),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
### Motivation
The user should be able to pin wanderlists to their homepage in order to make them easy to access. This widget allows these pinned wanderlists to be displayed on the homepage and elsewhere. Further changes were required to the cubit and state to get the pinned wanderlists from their profile.

### Changes
- Add new PinnedWanderlists widget for homepage
- Add a new constant for button corners for a more consistent look and feel
- Change cubit and state associated with loading user-related data