### PR TITLE
refine account page

### DIFF
--- a/lib/profile/cubit/profile_cubit.dart
+++ b/lib/profile/cubit/profile_cubit.dart
@@ -22,6 +22,6 @@ class ProfileCubit extends Cubit<ProfileState> {
       points += activity.points;
     });
     emit(ProfileLoaded(user.firstName, user.lastName, points,
-        "https://www.biography.com/.image/t_share/MTc0NjMzNDczMzM0NTg1MzM0/gettyimages-465470375.jpg"));
+        "", user));
   }
 }

--- a/lib/profile/cubit/profile_state.dart
+++ b/lib/profile/cubit/profile_state.dart
@@ -1,3 +1,4 @@
+import 'package:application/models/user.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/cupertino.dart';
 
@@ -10,8 +11,9 @@ class ProfileInitial implements ProfileState {
 }
 
 class ProfileLoaded extends Equatable implements ProfileState {
-  const ProfileLoaded(this.firstName, this.lastName, this.points, this.imgUrl);
+  const ProfileLoaded(this.firstName, this.lastName, this.points, this.imgUrl, this.user);
 
+  final UserDetails user;
   final String firstName;
   final String lastName;
   final int points;
@@ -25,12 +27,14 @@ class ProfileLoaded extends Equatable implements ProfileState {
     String? lastName,
     int? points,
     String? imgUrl,
+    UserDetails? user,
   }) {
     return ProfileLoaded(
       firstName ?? this.firstName,
       lastName ?? this.lastName,
       points ?? this.points,
       imgUrl ?? this.imgUrl,
+      user?? this.user,
     );
   }
 }

--- a/lib/profile/view/profile_page.dart
+++ b/lib/profile/view/profile_page.dart
@@ -166,8 +166,8 @@ class _UserInfo extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.center,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        Padding(padding: EdgeInsets.only(top: 8.0)),
         _name(firstName, lastName),
-        Padding(padding: EdgeInsets.only(top: 0.0)),
         _bigSmallText(context, "$points", "points"),
         _bigSmallText(context, "12", "completed activities"),
         Padding(padding: EdgeInsets.only(top: 18.0)),

--- a/lib/profile/view/profile_page.dart
+++ b/lib/profile/view/profile_page.dart
@@ -1,4 +1,7 @@
 import 'package:application/apptheme.dart';
+import 'package:application/components/activity_summary_item_small.dart';
+import 'package:application/models/activity.dart';
+import 'package:application/models/user.dart';
 import 'package:application/profile/cubit/profile_cubit.dart';
 import 'package:application/profile/cubit/profile_state.dart';
 import 'package:application/repositories/user/rest_user_repository.dart';
@@ -21,7 +24,7 @@ class _UserPhoto extends StatelessWidget {
             width: 144,
             decoration: BoxDecoration(
               shape: BoxShape.rectangle,
-              borderRadius: BorderRadius.all(Radius.circular(30.0)),
+              borderRadius: BorderRadius.all(Radius.circular(WanTheme.CARD_CORNER_RADIUS)),
               image: DecorationImage(
                 fit: BoxFit.fitHeight,
                 image: NetworkImage(state.imgUrl),
@@ -36,9 +39,47 @@ class _UserPhoto extends StatelessWidget {
   }
 }
 
-class _UserInfo extends StatelessWidget {
-  _UserInfo(this.firstName, this.lastName, this.points);
 
+class _ActivityHistoryPage extends StatelessWidget {
+
+  final List<ActivityDetails> activities;
+
+  const _ActivityHistoryPage(this.activities);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+    appBar: AppBar(title: Text("Activity History", style: TextStyle(color: WanTheme.colors.pink))),
+    body: _ActivityHistoryList(activities),
+    );
+  }
+
+}
+
+class _ActivityHistoryList extends StatelessWidget {
+  final List<ActivityDetails> activities;
+  _ActivityHistoryList(List<ActivityDetails> this.activities);
+
+  @override
+  Widget build(BuildContext context) {
+        return Container (child: ListView (
+          padding: EdgeInsets.all(8),
+            children: [
+              for (var activity in activities)
+                Container(
+                  padding: EdgeInsets.only(bottom: 8),
+                    child: ActivitySummaryItemSmall(activity: activity))
+        ]));
+
+
+  }
+
+}
+
+class _UserInfo extends StatelessWidget {
+  _UserInfo(this.firstName, this.lastName, this.points, this.user);
+
+  final UserDetails user;
   final String firstName;
   final String lastName;
   final int points;
@@ -80,110 +121,6 @@ class _UserInfo extends StatelessWidget {
   Widget _activityHistoryButton(BuildContext context) {
     return Container(
       height: 36,
-      width: 175,
-      child: ElevatedButton(
-        style: ButtonStyle(
-          padding: MaterialStateProperty.all<EdgeInsets>(
-            EdgeInsets.only(left: 10, right: 0),
-          ),
-          backgroundColor: MaterialStateProperty.all<Color>(
-            WanTheme.colors.purple,
-          ),
-          shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-            RoundedRectangleBorder(
-              borderRadius: BorderRadius.all(
-                Radius.circular(WanTheme.BUTTON_CORNER_RADIUS),
-              ),
-            ),
-          ),
-        ),
-        onPressed: () => {}, // TODO: make this go to the activity history page
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Text(
-              "Activity History",
-              style: TextStyle(
-                fontFamily: "inter",
-                fontSize: 14,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-            Icon(Icons.chevron_right, color: Colors.white),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget build(BuildContext context) {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        _name(firstName, lastName),
-        Padding(padding: EdgeInsets.only(top: 0.0)),
-        _bigSmallText(context, "$points", "points"),
-        _bigSmallText(context, "12", "completed activities"),
-        Padding(padding: EdgeInsets.only(top: 18.0)),
-        _activityHistoryButton(context),
-        Padding(padding: EdgeInsets.only(top: 8.0)),
-        _LogoutButton(),
-      ],
-    );
-  }
-}
-
-class _UserInfoContainer extends StatelessWidget {
-  static final cardRadius = Radius.circular(WanTheme.CARD_CORNER_RADIUS);
-
-  Container _buildInfoContainerWithChild(BuildContext context, Widget child) {
-    return Container(
-      height: 205,
-      decoration: BoxDecoration(
-        color: Theme.of(context).cardColor,
-        borderRadius: BorderRadius.only(
-          bottomLeft: cardRadius,
-          bottomRight: cardRadius,
-        ),
-      ),
-      padding: EdgeInsets.all(8.0),
-      alignment: Alignment.center,
-      child: child,
-    );
-  }
-
-  Widget build(BuildContext context) {
-    return BlocBuilder<ProfileCubit, ProfileState>(
-      buildWhen: (prev, next) => true,
-      builder: (context, state) {
-        if (state is ProfileInitial) {
-          return _buildInfoContainerWithChild(
-              context, CircularProgressIndicator());
-        } else if (state is ProfileLoaded) {
-          return _buildInfoContainerWithChild(
-            context,
-            Row(
-              children: [
-                _UserPhoto(),
-                Padding(padding: EdgeInsets.fromLTRB(20, 0, 0, 0)),
-                _UserInfo(state.firstName, state.lastName, state.points),
-              ],
-            ),
-          );
-        } else {
-          return Container(child: Text("Error!"));
-        }
-      },
-    );
-  }
-}
-
-class _LogoutButton extends StatelessWidget {
-  Widget build(BuildContext context) {
-    return Container(
-      height: 36,
-      width: 175,
       child: ElevatedButton(
         style: ButtonStyle(
           padding: MaterialStateProperty.all<EdgeInsets>(
@@ -200,22 +137,156 @@ class _LogoutButton extends StatelessWidget {
             ),
           ),
         ),
+        onPressed: () => Navigator.push(context,
+            MaterialPageRoute(builder: (context) => _ActivityHistoryPage(user.completedActivities))),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              "Activity History",
+              style: TextStyle(
+                fontFamily: "inter",
+                fontSize: 14,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          Container (
+            padding: EdgeInsets.only(right: 8),
+            child: Icon(Icons.chevron_right, color: Colors.white),
+          ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget build(BuildContext context) {
+    return BlocBuilder<ProfileCubit, ProfileState>(
+    builder: (context, state) => Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _name(firstName, lastName),
+        Padding(padding: EdgeInsets.only(top: 0.0)),
+        _bigSmallText(context, "$points", "points"),
+        _bigSmallText(context, "12", "completed activities"),
+        Padding(padding: EdgeInsets.only(top: 18.0)),
+        Row(
+            children: [
+                _activityHistoryButton(context),
+              Container(width: 8),
+              _LogoutButton()]),
+      ],
+    ));
+  }
+}
+
+class _ProfilePage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+
+    return BlocBuilder<ProfileCubit, ProfileState>(
+      builder: (context, state) {
+        if (state is ProfileInitial) {
+          return Center(child: CircularProgressIndicator());
+        } else if (state is ProfileLoaded) {
+          return Column(
+            mainAxisSize: MainAxisSize.max,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+              // info container
+                children: [
+                  Padding(padding: EdgeInsets.fromLTRB(20, 0, 0, 0)),
+                _UserInfo(state.firstName, state.lastName, state.points, state.user),
+                ],
+              ),
+            Expanded(child: RewardsList()),
+            ]);
+        } else {
+          return Container(child: Text("Error!"));
+        }
+      }
+    );
+
+  }
+
+}
+
+class _UserInfoContainer extends StatelessWidget {
+  static final cardRadius = Radius.circular(WanTheme.CARD_CORNER_RADIUS);
+
+  Material _buildInfoContainerWithChild(BuildContext context, Widget child) {
+    return Material(
+        child: Container (
+      padding: EdgeInsets.all(8.0),
+      child: child,
+    ));
+  }
+
+  Widget build(BuildContext context) {
+    return BlocBuilder<ProfileCubit, ProfileState>(
+      buildWhen: (prev, next) => true,
+      builder: (context, state) {
+        if (state is ProfileInitial) {
+          return Center(child: CircularProgressIndicator());
+        } else if (state is ProfileLoaded) {
+          return _buildInfoContainerWithChild(
+            context,
+            Row(
+              children: [
+                Padding(padding: EdgeInsets.fromLTRB(20, 0, 0, 0)),
+                _UserInfo(state.firstName, state.lastName, state.points, state.user),
+              ],
+            ),
+          );
+        } else {
+          return Container(child: Text("Error!"));
+        }
+      },
+    );
+  }
+}
+
+class _LogoutButton extends StatelessWidget {
+  Widget build(BuildContext context) {
+    return Container(
+      height: 36,
+      child: ElevatedButton(
+        style: ButtonStyle(
+          padding: MaterialStateProperty.all<EdgeInsets>(
+            EdgeInsets.only(left: 10, right: 0),
+          ),
+          backgroundColor: MaterialStateProperty.all<Color>(
+            WanTheme.colors.orange,
+          ),
+          shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+            RoundedRectangleBorder(
+              borderRadius: BorderRadius.all(
+                Radius.circular(WanTheme.BUTTON_CORNER_RADIUS),
+              ),
+            ),
+          ),
+        ),
         onPressed: () {
           FirebaseAuth.instance.signOut();
           Navigator.popUntil(context, ModalRoute.withName('/'));
         },
         child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            Icon(
-              Icons.logout,
-            ),
             Text(
-              "Log out",
+              "Log out  ",
               style: TextStyle(
-                color: Colors.white,
+                color: WanTheme.colors.white,
                 fontFamily: "inter",
               ),
             ),
+            Container (
+              padding: EdgeInsets.only(right: 8),
+              child: Icon(
+              Icons.logout,
+            )),
           ],
         ),
       ),
@@ -233,10 +304,10 @@ class ProfilePage extends StatelessWidget {
 
   AppBar _profileAppBar(BuildContext context) {
     return AppBar(
-      title: Text("Profile", style: Theme.of(context).textTheme.headline2),
-      actions: [_settingsButton()],
+      title: Text("Profile", style: TextStyle(color: WanTheme.colors.pink)),
+      // actions: [_settingsButton()],
       leading: new IconButton(
-        icon: new Icon(Icons.arrow_back, color: Colors.black),
+        icon: new Icon(Icons.arrow_back, color: WanTheme.colors.pink),
         onPressed: () => Navigator.of(context).pop(),
       ),
     );
@@ -249,14 +320,7 @@ class ProfilePage extends StatelessWidget {
         appBar: _profileAppBar(context),
         body: BlocListener<ProfileCubit, ProfileState>(
           listener: (context, state) {},
-          child: Column(
-            mainAxisSize: MainAxisSize.max,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              _UserInfoContainer(),
-              Expanded(child: RewardsList()),
-            ],
-          ),
+          child: _ProfilePage(),
         ),
       ),
     );

--- a/lib/rewards/view/reward_list.dart
+++ b/lib/rewards/view/reward_list.dart
@@ -22,7 +22,7 @@ class RewardsList extends StatelessWidget {
           ),
         ),
         TextSpan(
-          text: "Rewards",
+          text: " Rewards",
           style: Theme.of(context).textTheme.headline3,
         ),
       ]),


### PR DESCRIPTION
Motivation

The account page should match the visual style of the rest of the app, and should not have dead buttons. 

Changes

- remove account profile picture
- remove unused gear 'settings' icon
- implement activity history page
- Restyle AppBar to match rest of app