### PR TITLE
Add qr code scanner border

### DIFF
--- a/lib/checkin/view/qr_view.dart
+++ b/lib/checkin/view/qr_view.dart
@@ -46,12 +46,11 @@ class _QRViewExampleState extends State<_QRViewExample> {
       key: qrKey,
       onQRViewCreated: _onQRViewCreated,
       overlay: QrScannerOverlayShape(
-        borderColor: Colors.red,
-        overlayColor: Colors.transparent,
+        borderColor: Colors.pink,
         borderRadius: 10,
-        borderLength: 0,
-        borderWidth: 0,
-        cutOutSize: 400,
+        borderLength: 40,
+        borderWidth: 10,
+        cutOutSize: 250,
       ),
     );
   }


### PR DESCRIPTION
Change the QR code scanner to have a border

Note: It's not easy to have this without the area outside the frame being slightly opaque - let me know if you think this looks nicer or worse than the current scanner.
![image](https://user-images.githubusercontent.com/55824662/138264010-36b1efbd-24a9-4b9e-804a-a1939de7b86c.png)

