### PR TITLE
Wanderlist edit page redesign

### DIFF
--- a/lib/models/activity.dart
+++ b/lib/models/activity.dart
@@ -9,6 +9,7 @@ class ActivityDetails extends Equatable {
       this.address, this.points, this.tags);
 
   factory ActivityDetails.fromJson(Map<String, dynamic> json) {
+
     var a = ActivityDetails(
       json["id"],
       json['name'],

--- a/lib/repositories/activity/activity_repository.dart
+++ b/lib/repositories/activity/activity_repository.dart
@@ -4,7 +4,9 @@ import 'package:application/models/activity.dart';
 import 'package:application/repositories/activity/i_activity_repository.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
-class ActivityRepository implements IActivityRepository {
+/* deprecated */
+
+class ActivityRepository {
   final CollectionReference _activities =
       FirebaseFirestore.instance.collection('activities');
 
@@ -22,7 +24,6 @@ class ActivityRepository implements IActivityRepository {
 
   @override
   Future<List<ActivityDetails>> getActivities() async {
-    log("test");
     QuerySnapshot<Object?> snapshot = await _activities.limit(50).get();
     List<ActivityDetails> activities =
         snapshot.docs.map((DocumentSnapshot doc) {
@@ -30,7 +31,6 @@ class ActivityRepository implements IActivityRepository {
       data["id"] = doc.id;
       return ActivityDetails.fromJson(data);
     }).toList();
-    log("test");
     return activities;
   }
 }

--- a/lib/repositories/activity/i_activity_repository.dart
+++ b/lib/repositories/activity/i_activity_repository.dart
@@ -6,4 +6,5 @@ import 'package:application/models/activity.dart';
 abstract class IActivityRepository {
   Future<ActivityDetails> getActivity(String id);
   Future<List<ActivityDetails>> getActivities();
+  Future<List<ActivityDetails>> getSuggestForWanderlist(String wanderlistId);
 }

--- a/lib/repositories/activity/rest_activity_repository.dart
+++ b/lib/repositories/activity/rest_activity_repository.dart
@@ -17,10 +17,19 @@ class RestActivityRepository implements IActivityRepository {
 
   @override
   Future<List<ActivityDetails>> getActivities() async {
-    log("test");
     var data = await getDocument(restUri("activities", {"rec": "yes"})) as Map<String, dynamic>;
     List<ActivityDetails> activities = List.empty(growable: true);
     data["results"].forEach((json) => activities.add(ActivityDetails.fromJson(json)));
     return activities;
   }
+
+  @override
+  Future<List<ActivityDetails>> getSuggestForWanderlist(String wanderlistId) async {
+    var data = await getDocument(restUri("activities", {"wanderlist": wanderlistId})) as Map<String, dynamic>;
+    List<ActivityDetails> activities = List.empty(growable: true);
+    data["results"].forEach((json) => activities.add(ActivityDetails.fromJson(json)));
+    return activities;
+  }
+
+
 }

--- a/lib/wanderlist/cubit/suggestions_cubit.dart
+++ b/lib/wanderlist/cubit/suggestions_cubit.dart
@@ -4,14 +4,14 @@ import 'package:application/wanderlist/cubit/suggestions_state.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 class SuggestionsCubit extends Cubit<SuggestionsState> {
-  SuggestionsCubit(this.repository) : super(Initial());
+  SuggestionsCubit(this.repository, String wanderlistId) : super(Initial(wanderlistId));
 
   final IActivityRepository repository;
 
-  Future<void> loadSuggestions() async {
+  Future<void> loadSuggestions(String wanderlistId) async {
     if (state is Initial) {
       emit(Loading());
-      List<ActivityDetails> activities = await repository.getActivities();
+      List<ActivityDetails> activities = await repository.getSuggestForWanderlist(wanderlistId);
       emit(Loaded(activities));
     }
   }

--- a/lib/wanderlist/cubit/suggestions_state.dart
+++ b/lib/wanderlist/cubit/suggestions_state.dart
@@ -3,7 +3,12 @@ import 'package:equatable/equatable.dart';
 
 abstract class SuggestionsState {}
 
-class Initial implements SuggestionsState {}
+class Initial implements SuggestionsState {
+  final String wanderlistId;
+
+  Initial(this.wanderlistId);
+
+}
 
 class Loading implements SuggestionsState {}
 

--- a/lib/wanderlist/cubit/wanderlist_cubit.dart
+++ b/lib/wanderlist/cubit/wanderlist_cubit.dart
@@ -14,8 +14,10 @@ class WanderlistCubit extends Cubit<WanderlistState> {
   loadWanderlists(Wanderlist wanderlist) async {
     if (state is Initial) {
       emit(Loading());
-      await Future.delayed(Duration(seconds: 0));
-      emit(Viewing(wanderlist));
+      var newWl = await wanderlistRepository.getWanderlist(wanderlist.id);
+      //emit(Editing(_deepCopyActivityList(wanderlist), _deepCopyActivityList(wanderlist)));
+      // emit(Viewing(wanderlist));
+      startEdit(newWl);
     } else {
       emit(state);
     }
@@ -27,17 +29,12 @@ class WanderlistCubit extends Cubit<WanderlistState> {
   }
 
   startEdit(Wanderlist wanderlist) {
-    if (state is Viewing) {
-      emit(Editing(wanderlist, _deepCopyActivityList(wanderlist)));
-    } else {
-      emit(state);
-    }
+    emit(Editing(wanderlist, _deepCopyActivityList(wanderlist)));
   }
 
   endEdit() {
     if (state is Editing) {
       Wanderlist wanderlist = (state as Editing).wanderlist;
-      emit(Saving());
       _save(wanderlist);
       emit(Viewing(wanderlist));
     } else {
@@ -47,7 +44,7 @@ class WanderlistCubit extends Cubit<WanderlistState> {
 
   cancelEdit() {
     if (state is Editing) {
-      emit(Viewing((state as Editing).original));
+       emit(Viewing((state as Editing).original));
     } else {
       emit(state);
     }
@@ -55,7 +52,7 @@ class WanderlistCubit extends Cubit<WanderlistState> {
 
   madeEdit(Wanderlist wanderlist) {
     if (state is Editing) {
-      emit(Editing(wanderlist, (state as Editing).original));
+      emit(Editing(wanderlist, (state as Editing).original, isChanged: true));
     } else {
       emit(state);
     }
@@ -65,7 +62,7 @@ class WanderlistCubit extends Cubit<WanderlistState> {
     if (state is Editing) {
       (state as Editing).wanderlist.activities.add(activity);
       final original = (state as Editing).original;
-      emit(Editing(wanderlist, original));
+      emit(Editing(wanderlist, original, isChanged: true));
     } else {
       emit(state);
     }

--- a/lib/wanderlist/cubit/wanderlist_state.dart
+++ b/lib/wanderlist/cubit/wanderlist_state.dart
@@ -34,8 +34,9 @@ class Viewing implements WanderlistState {
 }
 
 class Editing implements WanderlistState {
-  Editing(this.wanderlist, this.original);
+  Editing(this.wanderlist, this.original, {this.isChanged: false});
 
+  final bool isChanged;
   final Wanderlist wanderlist;
   final Wanderlist original;
 

--- a/lib/wanderlist/view/edit_wanderlist.dart
+++ b/lib/wanderlist/view/edit_wanderlist.dart
@@ -87,12 +87,12 @@ class _EditWanderlistBody extends StatelessWidget {
       builder: (context, state) {
         if (state is Editing) {
           return
-              Padding (
+              Container (
                 padding: EdgeInsets.all(8),
               child: ListView (
                 children: [
                   Padding(
-                    padding: EdgeInsets.only(left: 48.0, right: 48.0),
+                    padding: EdgeInsets.only(left: 8.0, right: 8.0),
                     child: _EditNameTextfield(state.wanderlist.name),
                   ),
                   Padding(padding: EdgeInsets.only(top: 10)),
@@ -109,8 +109,7 @@ class _EditWanderlistBody extends StatelessWidget {
                             fontWeight: FontWeight.normal)),
                   ),
                   Padding(padding: EdgeInsets.only(top: 10)),
-                  Container(padding: EdgeInsets.symmetric(vertical: 0, horizontal: 8),
-                  child: ActivitySuggestions()),
+                  ActivitySuggestions(),
 
 
                 ],

--- a/lib/wanderlist/view/edit_wanderlist.dart
+++ b/lib/wanderlist/view/edit_wanderlist.dart
@@ -1,5 +1,6 @@
 import 'package:application/apptheme.dart';
 import 'package:application/components/activity_summary_item_small.dart';
+import 'package:application/components/searchfield.dart';
 import 'package:application/models/activity.dart';
 import 'package:application/models/user_wanderlist.dart';
 import 'package:application/models/wanderlist.dart';
@@ -29,49 +30,52 @@ class _AppBar extends StatelessWidget implements PreferredSizeWidget {
   Size get preferredSize => Size.fromHeight(barHeight);
 
   Widget _cancelButton(BuildContext context) {
-    return IconButton(
-      icon: Icon(Icons.close_rounded, color: Theme.of(context).accentColor),
+    return TextButton (
+      child: Row(children: [Icon(Icons.arrow_back, color: Theme.of(context).accentColor),
+        Text(" Cancel"),
+      ]),
       onPressed: () {
-        context.read<WanderlistCubit>().cancelEdit();
+         context.read<WanderlistCubit>().cancelEdit();
+         Navigator.of(context).pop(true);
       },
     );
   }
 
   Widget _saveButton(BuildContext context) {
-    return ElevatedButton(
+    return TextButton (
         onPressed: () {
           context.read<WanderlistCubit>().endEdit();
+          Navigator.of(context).pop(true);
         },
-        child: Text("Save"));
+        child: Row (children: [Icon(Icons.check_rounded),
+          Text("  Save")]));
   }
 
   @override
   Widget build(BuildContext context) {
     return BlocConsumer<WanderlistCubit, WanderlistState>(
-      builder: (context, state) {
-        return Container(
-          child: SafeArea(
-            child: AppBar(
-              backgroundColor: Colors.white12,
-              foregroundColor: Colors.black,
-              elevation: 0,
-              actions: [
-                Padding(
-                  padding: const EdgeInsets.all(6.0),
-                  child: _saveButton(context),
-                )
-              ],
-              leading: _cancelButton(context),
-              title: Text("Editing Wanderlist",
-                  style: TextStyle(
-                      fontSize: 14,
-                      fontStyle: FontStyle.normal,
-                      fontFamily: "Inter")),
-            ),
-          ),
-        );
-      },
       listener: (context, state) => {},
+      builder: (context, state) {
+        if (state is Editing) {
+          if (state.isChanged) {
+            return AppBar(
+              backgroundColor: Colors.white,
+              title: Text("Wanderlist", style: TextStyle(color: WanTheme.colors.pink)),
+              centerTitle: true,
+              actions: [_saveButton(context)],
+              leading: _cancelButton(context),
+              leadingWidth: 100,
+            );
+          } else {
+            return AppBar(
+              backgroundColor: Colors.white,
+              title: Text("Wanderlist", style: TextStyle(color: WanTheme.colors.pink)),
+              centerTitle: true,
+            );
+          }
+          }
+        return Container();
+      }
     );
   }
 }
@@ -82,10 +86,10 @@ class _EditWanderlistBody extends StatelessWidget {
     return BlocConsumer<WanderlistCubit, WanderlistState>(
       builder: (context, state) {
         if (state is Editing) {
-          return Stack(
-            children: [
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.center,
+          return
+              Padding (
+                padding: EdgeInsets.all(8),
+              child: ListView (
                 children: [
                   Padding(
                     padding: EdgeInsets.only(left: 48.0, right: 48.0),
@@ -94,11 +98,23 @@ class _EditWanderlistBody extends StatelessWidget {
                   Padding(padding: EdgeInsets.only(top: 10)),
                   _EditableActivityList(state.wanderlist.activities),
                   Padding(padding: EdgeInsets.only(top: 10)),
+                  //SearchField("Search Activities"),
+                  Container(
+                    alignment: Alignment.centerLeft,
+                    child: Text("Suggestions",
+                        style: TextStyle(
+                            fontSize: 18,
+                            color: Colors.black,
+                            fontFamily: 'Inter',
+                            fontWeight: FontWeight.normal)),
+                  ),
+                  Padding(padding: EdgeInsets.only(top: 10)),
+                  Container(padding: EdgeInsets.symmetric(vertical: 0, horizontal: 8),
+                  child: ActivitySuggestions()),
+
+
                 ],
-              ),
-              AddActivityOverlay(),
-            ],
-          );
+              ));
         }
 
         return CircularProgressIndicator();
@@ -127,12 +143,12 @@ class _EditNameTextfield extends StatelessWidget {
       builder: (context, WanderlistState state) {
         if (state is Editing) {
           return TextField(
+            style: TextStyle(color: Colors.black,
+            fontSize: 24),
             textAlign: TextAlign.center,
+            maxLines: null,
+            keyboardType: TextInputType.text,
             controller: _controller,
-            onTap: () => _controller.selection = TextSelection(
-              baseOffset: 0,
-              extentOffset: _controller.value.text.length,
-            ),
             onSubmitted: (text) => _submitNewName(context, state, text),
           );
         }
@@ -165,7 +181,6 @@ class _EditableActivityList extends StatelessWidget {
         builder: (context, state) {
           if (state is Editing) {
             return Container(
-              width: MediaQuery.of(context).size.width * 0.95,
               padding: EdgeInsets.all(WanTheme.CARD_PADDING),
               decoration: BoxDecoration(
                   borderRadius:
@@ -173,11 +188,13 @@ class _EditableActivityList extends StatelessWidget {
                   color: Colors.white),
               child: ReorderableListView.builder(
                 shrinkWrap: true,
+                physics: NeverScrollableScrollPhysics(),
                 itemBuilder: (context, index) {
                   return _EditableActivityListItem(
                     Key('$index'),
                     activities[index],
                     () => _onRemoveItem(context, state, index),
+                    true,
                   );
                 },
                 itemCount: activities.length,
@@ -203,33 +220,32 @@ class _EditableActivityList extends StatelessWidget {
 }
 
 class _EditableActivityListItem extends StatelessWidget {
-  _EditableActivityListItem(this.key, this.activity, this.remove);
+  _EditableActivityListItem(this.key, this.activity, this.remove, this.showRemove);
 
+  final bool showRemove;
   final Key key;
   final ActivityDetails activity;
   final Function() remove;
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      child: Row(
-        children: [
-          IconButton(
-            icon:
-                Icon(Icons.remove_circle_outline_outlined, color: Colors.grey),
-            onPressed: () {
-              remove();
-            },
+    if (showRemove) {
+      return ActivitySummaryItemSmall(
+          width: MediaQuery.of(context).size.width,
+          activity: activity,
+          rightWidget: IconButton(icon:
+          Icon(Icons.remove_circle_outline_outlined, color: Colors.grey),
+            onPressed: () => remove(),
           ),
-          ActivitySummaryItemSmall(
-            width: MediaQuery.of(context).size.width * 0.75,
-            activity: activity,
-            rightWidget: Icon(Icons.drag_handle, color: Colors.grey),
-            smallIcon: true,
-          ),
-        ],
-      ),
-    );
+          smallIcon: true,
+        );
+    } else {
+      return ActivitySummaryItemSmall(
+        width: MediaQuery.of(context).size.width,
+        activity: activity,
+        smallIcon: true,
+      );
+    }
   }
 }
 

--- a/lib/wanderlist/view/wanderlist.dart
+++ b/lib/wanderlist/view/wanderlist.dart
@@ -27,7 +27,7 @@ class WanderlistPage extends StatelessWidget {
               create: (context) => WanderlistCubit(RestWanderlistRepository()),
             ),
             BlocProvider<SuggestionsCubit>(
-              create: (context) => SuggestionsCubit(RestActivityRepository()),
+              create: (context) => SuggestionsCubit(RestActivityRepository(), wanderlist.id),
             ),
           ],
           child: _PageContent(wanderlist.wanderlist),

--- a/lib/wanderlist/view/wanderlist.dart
+++ b/lib/wanderlist/view/wanderlist.dart
@@ -53,14 +53,14 @@ class _PageContent extends StatelessWidget {
         } else if (state is Editing) {
           return EditWanderlistPage(state.wanderlist);
         } else if (state is Saving) {
-          return CircularProgressIndicator();
+          return Center( child: CircularProgressIndicator());
         } else if (state is Saved) {
           Navigator.of(context).pop();
         } else {
           context.read<WanderlistCubit>().loadWanderlists(wanderlist);
         }
 
-        return CircularProgressIndicator();
+        return Center (child: CircularProgressIndicator());
       },
       listener: (context, state) {},
     );

--- a/lib/wanderlist/widgets/add_activity.dart
+++ b/lib/wanderlist/widgets/add_activity.dart
@@ -67,14 +67,19 @@ class ActivitySuggestions extends StatelessWidget {
       buildWhen: (t, n) => t != n,
       builder: (context, state) {
         if (state is suggestionsState.Initial) {
-          context.read<SuggestionsCubit>().loadSuggestions();
+          context.read<SuggestionsCubit>().loadSuggestions(state.wanderlistId);
         } else if (state is suggestionsState.Loaded) {
-          return Column (
+          return Material (
+              borderRadius: BorderRadius.all(Radius.circular(WanTheme.CARD_CORNER_RADIUS)),
+          color: Colors.white,
+          child: Container (
+            padding: EdgeInsets.symmetric(horizontal: 8),
+              child: Column (
             children: [
               for (var activity in state.activities)
-                _SuggestionsItem(activity)
+                _SuggestionsItem(activity),
             ]
-          );
+          )));
         }
 
         return Container();

--- a/lib/wanderlist/widgets/add_activity.dart
+++ b/lib/wanderlist/widgets/add_activity.dart
@@ -48,7 +48,7 @@ class AddActivityOverlay extends StatelessWidget {
                       fontFamily: 'Inter',
                       fontWeight: FontWeight.normal)),
             ),
-            Container(height: 345, child: _Suggestions()),
+            Container(height: 345, child: ActivitySuggestions()),
           ],
         ),
       ),
@@ -60,28 +60,24 @@ class AddActivityOverlay extends StatelessWidget {
   }
 }
 
-class _Suggestions extends StatelessWidget {
+class ActivitySuggestions extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocConsumer<SuggestionsCubit, suggestionsState.SuggestionsState>(
+      buildWhen: (t, n) => t != n,
       builder: (context, state) {
         if (state is suggestionsState.Initial) {
           context.read<SuggestionsCubit>().loadSuggestions();
-        } else if (state is suggestionsState.Loading) {
-          return CircularProgressIndicator();
         } else if (state is suggestionsState.Loaded) {
-          return ListView.builder(
-            shrinkWrap: true,
-            itemCount: state.activities.length,
-            itemBuilder: (context, index) {
-              return _SuggestionsItem(state.activities[index]);
-            },
-            physics: const BouncingScrollPhysics(
-                parent: AlwaysScrollableScrollPhysics()),
+          return Column (
+            children: [
+              for (var activity in state.activities)
+                _SuggestionsItem(activity)
+            ]
           );
         }
 
-        return CircularProgressIndicator();
+        return Container();
       },
       listener: (context, state) => {},
     );
@@ -94,20 +90,10 @@ class _SuggestionsItem extends StatelessWidget {
   final ActivityDetails activity;
 
   Widget addButton(BuildContext context, wanderlistState.Editing state) {
-    return ElevatedButton(
-      style: ElevatedButton.styleFrom(
-        elevation: 0.0,
-        shadowColor: Colors.transparent,
-      ),
-      onPressed: () {
-        context.read<WanderlistCubit>().addActivity(state.wanderlist, activity);
-      },
-      child: Text(
-        "Add",
-        style:
-            TextStyle(fontSize: 10, fontFamily: "Inter", color: Colors.white),
-      ),
-    );
+    return IconButton(icon: Icon(Icons.add_circle_outline_rounded),
+          color: WanColors().pink, onPressed: () {
+              context.read<WanderlistCubit>().addActivity(state.wanderlist, activity);
+            });
   }
 
   Widget successfullyAddedIcon() {
@@ -145,7 +131,6 @@ class _SuggestionsItem extends StatelessWidget {
                   activity: activity,
                   smallIcon: true,
                   rightWidget: Container(
-                    height: 20,
                     child: pickItemIcon(context, state),
                   ),
                 ),


### PR DESCRIPTION
Motivation: 

The wanderlist edit page should be simple to navigate and match the visual style of the rest of the app

Changes

- there is now no explicit edit button, instead it is always editable and a save button appears once a change is made
- Suggestions list is now displayed below the items in the wanderlist rather than as a separate pull up drawer
- uses the per-wanderlist recommendation api endpoint